### PR TITLE
feature/backend/APS Bucketの詳細情報の取得機能の実装

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -85,6 +85,50 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/aps/buckets/{bucketKey}/details": {
+            "get": {
+                "description": "指定されたバケットの詳細情報を取得します",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "APS Bucket"
+                ],
+                "summary": "APSバケット詳細取得",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "バケットキー",
+                        "name": "bucketKey",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.APSBucketDetail"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/aps_bucket.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/aps_bucket.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/aps/token": {
             "post": {
                 "description": "2-legged認証でAPSアクセストークンを取得します",
@@ -141,6 +185,29 @@ const docTemplate = `{
                 }
             }
         },
+        "domain.APSBucketDetail": {
+            "type": "object",
+            "properties": {
+                "bucketKey": {
+                    "type": "string"
+                },
+                "bucketOwner": {
+                    "type": "string"
+                },
+                "createdDate": {
+                    "type": "integer"
+                },
+                "permissions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Permission"
+                    }
+                },
+                "policyKey": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.APSToken": {
             "description": "APSトークンレスポンス",
             "type": "object",
@@ -160,6 +227,17 @@ const docTemplate = `{
                 "token_type": {
                     "type": "string",
                     "example": "Bearer"
+                }
+            }
+        },
+        "domain.Permission": {
+            "type": "object",
+            "properties": {
+                "access": {
+                    "type": "string"
+                },
+                "authId": {
+                    "type": "string"
                 }
             }
         }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -78,6 +78,50 @@
                 }
             }
         },
+        "/api/v1/aps/buckets/{bucketKey}/details": {
+            "get": {
+                "description": "指定されたバケットの詳細情報を取得します",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "APS Bucket"
+                ],
+                "summary": "APSバケット詳細取得",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "バケットキー",
+                        "name": "bucketKey",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.APSBucketDetail"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/aps_bucket.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/aps_bucket.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/aps/token": {
             "post": {
                 "description": "2-legged認証でAPSアクセストークンを取得します",
@@ -134,6 +178,29 @@
                 }
             }
         },
+        "domain.APSBucketDetail": {
+            "type": "object",
+            "properties": {
+                "bucketKey": {
+                    "type": "string"
+                },
+                "bucketOwner": {
+                    "type": "string"
+                },
+                "createdDate": {
+                    "type": "integer"
+                },
+                "permissions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Permission"
+                    }
+                },
+                "policyKey": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.APSToken": {
             "description": "APSトークンレスポンス",
             "type": "object",
@@ -153,6 +220,17 @@
                 "token_type": {
                     "type": "string",
                     "example": "Bearer"
+                }
+            }
+        },
+        "domain.Permission": {
+            "type": "object",
+            "properties": {
+                "access": {
+                    "type": "string"
+                },
+                "authId": {
+                    "type": "string"
                 }
             }
         }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -13,6 +13,21 @@ definitions:
       policyKey:
         type: string
     type: object
+  domain.APSBucketDetail:
+    properties:
+      bucketKey:
+        type: string
+      bucketOwner:
+        type: string
+      createdDate:
+        type: integer
+      permissions:
+        items:
+          $ref: '#/definitions/domain.Permission'
+        type: array
+      policyKey:
+        type: string
+    type: object
   domain.APSToken:
     description: APSトークンレスポンス
     properties:
@@ -27,6 +42,13 @@ definitions:
         type: string
       token_type:
         example: Bearer
+        type: string
+    type: object
+  domain.Permission:
+    properties:
+      access:
+        type: string
+      authId:
         type: string
     type: object
 host: localhost:8080
@@ -79,6 +101,35 @@ paths:
           schema:
             $ref: '#/definitions/aps_bucket.ErrorResponse'
       summary: APSバケット作成
+      tags:
+      - APS Bucket
+  /api/v1/aps/buckets/{bucketKey}/details:
+    get:
+      consumes:
+      - application/json
+      description: 指定されたバケットの詳細情報を取得します
+      parameters:
+      - description: バケットキー
+        in: path
+        name: bucketKey
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/domain.APSBucketDetail'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/aps_bucket.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/aps_bucket.ErrorResponse'
+      summary: APSバケット詳細取得
       tags:
       - APS Bucket
   /api/v1/aps/token:

--- a/backend/internal/domain/aps_bucket.go
+++ b/backend/internal/domain/aps_bucket.go
@@ -16,7 +16,18 @@ type Permission struct {
     Access string `json:"access"`
 }
 
+// APSBucketDetail はバケットの詳細情報を表す構造体
+type APSBucketDetail struct {
+    BucketKey    string       `json:"bucketKey"`
+    BucketOwner  string       `json:"bucketOwner"`
+    CreatedDate  int64        `json:"createdDate"`
+    Permissions  []Permission `json:"permissions"`
+    PolicyKey    string       `json:"policyKey"`
+}
+
+// APSBucketRepository インターフェースに詳細取得メソッドを追加
 type APSBucketRepository interface {
     CreateBucket(token string) (*APSBucket, error)
     GetBuckets(token string) (*BucketsResponse, error)
+    GetBucketDetail(token string, bucketKey string) (*APSBucketDetail, error) // 追加
 }

--- a/backend/internal/infrastructure/aps/aps_bucket/get_detail.go
+++ b/backend/internal/infrastructure/aps/aps_bucket/get_detail.go
@@ -1,0 +1,38 @@
+package aps_bucket
+
+import (
+    "encoding/json"
+    "fmt"
+    "net/http"
+
+    "github.com/maixhashi/nextgo-aps-viewer/backend/internal/domain"
+)
+
+func (r *APSBucketRepository) GetBucketDetail(token string, bucketKey string) (*domain.APSBucketDetail, error) {
+    url := fmt.Sprintf("https://developer.api.autodesk.com/oss/v2/buckets/%s/details", bucketKey)
+    
+    req, err := http.NewRequest("GET", url, nil)
+    if err != nil {
+        return nil, err
+    }
+
+    req.Header.Set("Authorization", "Bearer "+token)
+    req.Header.Set("Content-Type", "application/json")
+
+    resp, err := r.client.Do(req)
+    if err != nil {
+        return nil, err
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusOK {
+        return nil, fmt.Errorf("API request failed with status: %d", resp.StatusCode)
+    }
+
+    var detail domain.APSBucketDetail
+    if err := json.NewDecoder(resp.Body).Decode(&detail); err != nil {
+        return nil, err
+    }
+
+    return &detail, nil
+}

--- a/backend/internal/interface/handler/aps_bucket/get_detail.go
+++ b/backend/internal/interface/handler/aps_bucket/get_detail.go
@@ -1,0 +1,31 @@
+package aps_bucket
+
+import (
+    "encoding/json"
+    "net/http"
+    "github.com/gorilla/mux"
+)
+
+// @Summary APSバケット詳細取得
+// @Description 指定されたバケットの詳細情報を取得します
+// @Tags APS Bucket
+// @Accept json
+// @Produce json
+// @Param bucketKey path string true "バケットキー"
+// @Success 200 {object} domain.APSBucketDetail
+// @Failure 400 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /api/v1/aps/buckets/{bucketKey}/details [get]
+func (h *APSBucketHandler) GetBucketDetail(w http.ResponseWriter, r *http.Request) {
+    vars := mux.Vars(r)
+    bucketKey := vars["bucketKey"]
+
+    detail, err := h.bucketUseCase.GetBucketDetail(bucketKey)
+    if err != nil {
+        http.Error(w, err.Error(), http.StatusInternalServerError)
+        return
+    }
+
+    w.Header().Set("Content-Type", "application/json")
+    json.NewEncoder(w).Encode(detail)
+}

--- a/backend/internal/interface/router/aps_bucket_router.go
+++ b/backend/internal/interface/router/aps_bucket_router.go
@@ -8,4 +8,5 @@ import (
 func RegisterAPSBucketRoutes(r *mux.Router, h *aps_bucket.APSBucketHandler) {
     r.HandleFunc("/api/v1/aps/buckets", h.CreateBucket).Methods("POST")
     r.HandleFunc("/api/v1/aps/buckets", h.GetBuckets).Methods("GET")
+    r.HandleFunc("/api/v1/aps/buckets/{bucketKey}/details", h.GetBucketDetail).Methods("GET")
 }

--- a/backend/internal/interface/router/main.go
+++ b/backend/internal/interface/router/main.go
@@ -25,7 +25,7 @@ func NewRouter() *mux.Router {
     apsTokenHandler := aps_token.NewAPSTokenHandler(apsTokenUseCase)
     apsBucketHandler := aps_bucket.NewAPSBucketHandler(apsBucketUseCase)
     
-    // Register routes
+    // Register routes using modular router files
     RegisterAPSTokenRoutes(r, apsTokenHandler)
     RegisterAPSBucketRoutes(r, apsBucketHandler)
     

--- a/backend/internal/usecase/aps_bucket/get_detail.go
+++ b/backend/internal/usecase/aps_bucket/get_detail.go
@@ -1,0 +1,12 @@
+package aps_bucket
+
+import "github.com/maixhashi/nextgo-aps-viewer/backend/internal/domain"
+
+func (u *APSBucketUseCase) GetBucketDetail(bucketKey string) (*domain.APSBucketDetail, error) {
+    token, err := u.tokenUseCase.GetToken()
+    if err != nil {
+        return nil, err
+    }
+
+    return u.bucketRepo.GetBucketDetail(token.AccessToken, bucketKey)
+}


### PR DESCRIPTION
# バケット詳細取得APIの実装

## 概要
APSのOSS APIを使用してバケットの詳細情報を取得するエンドポイントを実装しました。

## 変更内容
- バケット詳細情報を表す`APSBucketDetail`構造体の追加
- バケット詳細取得のリポジトリインターフェースとメソッドの追加
- バケット詳細取得のユースケース実装
- バケット詳細取得のハンドラー実装
- APIルートの追加
- Swagger APIドキュメントの更新

## 実装詳細
- エンドポイント: `GET /api/v1/aps/buckets/{bucketKey}/details`
- レスポンス: バケットの詳細情報（所有者、作成日、権限など）
- 認証: Bearer トークンによる認証

## テスト項目
- バケット詳細取得APIの正常系テスト
- 不正なバケットキーの場合のエラーハンドリング
- 認証エラーのハンドリング

## 関連
close #10 
