### PR TITLE
feature/backend/APS Bucket削除機能の実装

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -85,6 +85,47 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/aps/buckets/{bucketKey}": {
+            "delete": {
+                "description": "指定されたバケットを削除します",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "APS Bucket"
+                ],
+                "summary": "APSバケット削除",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "バケットキー",
+                        "name": "bucketKey",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/aps_bucket.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/aps_bucket.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/aps/buckets/{bucketKey}/details": {
             "get": {
                 "description": "指定されたバケットの詳細情報を取得します",

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -78,6 +78,47 @@
                 }
             }
         },
+        "/api/v1/aps/buckets/{bucketKey}": {
+            "delete": {
+                "description": "指定されたバケットを削除します",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "APS Bucket"
+                ],
+                "summary": "APSバケット削除",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "バケットキー",
+                        "name": "bucketKey",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/aps_bucket.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/aps_bucket.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/aps/buckets/{bucketKey}/details": {
             "get": {
                 "description": "指定されたバケットの詳細情報を取得します",

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -103,6 +103,33 @@ paths:
       summary: APSバケット作成
       tags:
       - APS Bucket
+  /api/v1/aps/buckets/{bucketKey}:
+    delete:
+      consumes:
+      - application/json
+      description: 指定されたバケットを削除します
+      parameters:
+      - description: バケットキー
+        in: path
+        name: bucketKey
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/aps_bucket.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/aps_bucket.ErrorResponse'
+      summary: APSバケット削除
+      tags:
+      - APS Bucket
   /api/v1/aps/buckets/{bucketKey}/details:
     get:
       consumes:

--- a/backend/internal/domain/aps_bucket.go
+++ b/backend/internal/domain/aps_bucket.go
@@ -29,5 +29,6 @@ type APSBucketDetail struct {
 type APSBucketRepository interface {
     CreateBucket(token string) (*APSBucket, error)
     GetBuckets(token string) (*BucketsResponse, error)
-    GetBucketDetail(token string, bucketKey string) (*APSBucketDetail, error) // 追加
+    GetBucketDetail(token string, bucketKey string) (*APSBucketDetail, error)
+    DeleteBucket(token string, bucketKey string) error // 追加
 }

--- a/backend/internal/infrastructure/aps/aps_bucket/aps_bucket.go
+++ b/backend/internal/infrastructure/aps/aps_bucket/aps_bucket.go
@@ -5,11 +5,13 @@ import (
 )
 
 type APSBucketRepository struct {
-    client *http.Client
+    client  *http.Client
+    baseURL string
 }
 
-func NewAPSBucketRepository() *APSBucketRepository {
+func NewAPSBucketRepository(client *http.Client) *APSBucketRepository {
     return &APSBucketRepository{
-        client: &http.Client{},
+        client:  client,
+        baseURL: "https://developer.api.autodesk.com/oss/v2",
     }
 }

--- a/backend/internal/infrastructure/aps/aps_bucket/delete.go
+++ b/backend/internal/infrastructure/aps/aps_bucket/delete.go
@@ -1,0 +1,29 @@
+package aps_bucket
+
+import (
+    "fmt"
+    "net/http"
+)
+
+func (r *APSBucketRepository) DeleteBucket(token string, bucketKey string) error {
+    url := fmt.Sprintf("%s/buckets/%s", r.baseURL, bucketKey)
+    
+    req, err := http.NewRequest("DELETE", url, nil)
+    if err != nil {
+        return err
+    }
+
+    req.Header.Set("Authorization", "Bearer "+token)
+
+    resp, err := r.client.Do(req)
+    if err != nil {
+        return err
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusOK {
+        return fmt.Errorf("failed to delete bucket: %d", resp.StatusCode)
+    }
+
+    return nil
+}

--- a/backend/internal/infrastructure/aps/aps_token/get.go
+++ b/backend/internal/infrastructure/aps/aps_token/get.go
@@ -16,7 +16,7 @@ func (r *APSTokenRepository) GetToken() (*domain.APSToken, error) {
     
     data := url.Values{}
     data.Set("grant_type", "client_credentials")
-    data.Set("scope", "data:read bucket:read bucket:create") 
+    data.Set("scope", "data:read bucket:read bucket:create bucket:delete") 
     
     req, err := http.NewRequest("POST", "https://developer.api.autodesk.com/authentication/v2/token", 
         strings.NewReader(data.Encode()))

--- a/backend/internal/interface/handler/aps_bucket/delete.go
+++ b/backend/internal/interface/handler/aps_bucket/delete.go
@@ -1,0 +1,28 @@
+package aps_bucket
+
+import (
+    "net/http"
+    "github.com/gorilla/mux"
+)
+
+// @Summary APSバケット削除
+// @Description 指定されたバケットを削除します
+// @Tags APS Bucket
+// @Accept json
+// @Produce json
+// @Param bucketKey path string true "バケットキー"
+// @Success 200 
+// @Failure 400 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /api/v1/aps/buckets/{bucketKey} [delete]
+func (h *APSBucketHandler) DeleteBucket(w http.ResponseWriter, r *http.Request) {
+    vars := mux.Vars(r)
+    bucketKey := vars["bucketKey"]
+
+    if err := h.bucketUseCase.DeleteBucket(bucketKey); err != nil {
+        http.Error(w, err.Error(), http.StatusInternalServerError)
+        return
+    }
+
+    w.WriteHeader(http.StatusOK)
+}

--- a/backend/internal/interface/router/aps_bucket_router.go
+++ b/backend/internal/interface/router/aps_bucket_router.go
@@ -9,4 +9,5 @@ func RegisterAPSBucketRoutes(r *mux.Router, h *aps_bucket.APSBucketHandler) {
     r.HandleFunc("/api/v1/aps/buckets", h.CreateBucket).Methods("POST")
     r.HandleFunc("/api/v1/aps/buckets", h.GetBuckets).Methods("GET")
     r.HandleFunc("/api/v1/aps/buckets/{bucketKey}/details", h.GetBucketDetail).Methods("GET")
+    r.HandleFunc("/api/v1/aps/buckets/{bucketKey}", h.DeleteBucket).Methods("DELETE")
 }

--- a/backend/internal/interface/router/main.go
+++ b/backend/internal/interface/router/main.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+    "net/http"
     "github.com/gorilla/mux"
     aps_token_repo "github.com/maixhashi/nextgo-aps-viewer/backend/internal/infrastructure/aps/aps_token"
     aps_bucket_repo "github.com/maixhashi/nextgo-aps-viewer/backend/internal/infrastructure/aps/aps_bucket"
@@ -13,9 +14,12 @@ import (
 func NewRouter() *mux.Router {
     r := mux.NewRouter()
     
+    // Initialize HTTP client
+    httpClient := &http.Client{}
+    
     // Initialize repositories
     apsTokenRepo := aps_token_repo.NewAPSTokenRepository()
-    apsBucketRepo := aps_bucket_repo.NewAPSBucketRepository()
+    apsBucketRepo := aps_bucket_repo.NewAPSBucketRepository(httpClient)
     
     // Initialize use cases
     apsTokenUseCase := token_usecase.NewAPSTokenUseCase(apsTokenRepo)

--- a/backend/internal/usecase/aps_bucket/delete.go
+++ b/backend/internal/usecase/aps_bucket/delete.go
@@ -1,0 +1,10 @@
+package aps_bucket
+
+func (u *APSBucketUseCase) DeleteBucket(bucketKey string) error {
+    token, err := u.tokenUseCase.GetToken()
+    if err != nil {
+        return err
+    }
+
+    return u.bucketRepo.DeleteBucket(token.AccessToken, bucketKey)
+}


### PR DESCRIPTION
# APS バケット削除機能の実装

## 概要
Autodesk Platform Services (APS) のバケット削除機能を実装しました。この機能により、ユーザーは不要になったバケットを削除することができます。

## 実装内容
- APSBucketRepository インターフェースに DeleteBucket メソッドを追加
- バケット削除のためのユースケース実装
- バケット削除のためのハンドラー実装
- バケット削除のためのリポジトリ実装（APS API呼び出し）
- 削除エンドポイント（DELETE /api/v1/aps/buckets/{bucketKey}）のルーティング設定

## 技術的詳細
- APS API の DELETE /buckets/:bucketKey エンドポイントを使用
- 認証トークンを取得してAPIリクエストを行う処理を実装
- エラーハンドリングを適切に実装（ステータスコードの確認など）

## 関連
close #12 

## 参考資料
- [DELETE buckets/:bucketKey | Data Management API | Autodesk Platform Services](https://aps.autodesk.com/en/docs/data/v2/reference/http/buckets-:bucketKey-DELETE/)
