### PR TITLE
feature/backend/APS ObjectのS3署名付きURLへのアップロード機能の実装

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -228,6 +228,126 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/aps/buckets/{bucketKey}/objects/upload": {
+            "post": {
+                "description": "S3署名付きURLを取得してオブジェクトをアップロードするシーケンスを実行します",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "APS Object"
+                ],
+                "summary": "APSオブジェクトのアップロードシーケンス",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "バケットキー",
+                        "name": "bucketKey",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "アップロードするファイル",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "パート数",
+                        "name": "parts",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/aps_object.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/aps_object.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/aps/objects/signeds3upload": {
+            "put": {
+                "description": "S3署名付きURLを使用してオブジェクトをS3へアップロードします",
+                "consumes": [
+                    "application/octet-stream"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "APS Object"
+                ],
+                "summary": "S3署名付きURLを使用したオブジェクトのアップロード",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "署名付きURL",
+                        "name": "signedURL",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "description": "アップロードするファイルのバイナリデータ",
+                        "name": "file",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/aps_object.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/aps_object.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/aps/token": {
             "post": {
                 "description": "2-legged認証でAPSアクセストークンを取得します",

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -221,6 +221,126 @@
                 }
             }
         },
+        "/api/v1/aps/buckets/{bucketKey}/objects/upload": {
+            "post": {
+                "description": "S3署名付きURLを取得してオブジェクトをアップロードするシーケンスを実行します",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "APS Object"
+                ],
+                "summary": "APSオブジェクトのアップロードシーケンス",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "バケットキー",
+                        "name": "bucketKey",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "アップロードするファイル",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "パート数",
+                        "name": "parts",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/aps_object.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/aps_object.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/aps/objects/signeds3upload": {
+            "put": {
+                "description": "S3署名付きURLを使用してオブジェクトをS3へアップロードします",
+                "consumes": [
+                    "application/octet-stream"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "APS Object"
+                ],
+                "summary": "S3署名付きURLを使用したオブジェクトのアップロード",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "署名付きURL",
+                        "name": "signedURL",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "description": "アップロードするファイルのバイナリデータ",
+                        "name": "file",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/aps_object.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/aps_object.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/aps/token": {
             "post": {
                 "description": "2-legged認証でAPSアクセストークンを取得します",

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -216,6 +216,86 @@ paths:
       summary: S3署名付きURLの取得
       tags:
       - APS Object
+  /api/v1/aps/buckets/{bucketKey}/objects/upload:
+    post:
+      consumes:
+      - multipart/form-data
+      description: S3署名付きURLを取得してオブジェクトをアップロードするシーケンスを実行します
+      parameters:
+      - description: バケットキー
+        in: path
+        name: bucketKey
+        required: true
+        type: string
+      - description: アップロードするファイル
+        in: formData
+        name: file
+        required: true
+        type: file
+      - default: 1
+        description: パート数
+        in: query
+        name: parts
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/aps_object.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/aps_object.ErrorResponse'
+      summary: APSオブジェクトのアップロードシーケンス
+      tags:
+      - APS Object
+  /api/v1/aps/objects/signeds3upload:
+    put:
+      consumes:
+      - application/octet-stream
+      description: S3署名付きURLを使用してオブジェクトをS3へアップロードします
+      parameters:
+      - description: 署名付きURL
+        in: query
+        name: signedURL
+        required: true
+        type: string
+      - description: アップロードするファイルのバイナリデータ
+        in: body
+        name: file
+        required: true
+        schema:
+          items:
+            type: integer
+          type: array
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/aps_object.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/aps_object.ErrorResponse'
+      summary: S3署名付きURLを使用したオブジェクトのアップロード
+      tags:
+      - APS Object
   /api/v1/aps/token:
     post:
       consumes:

--- a/backend/internal/domain/aps_object.go
+++ b/backend/internal/domain/aps_object.go
@@ -13,9 +13,11 @@ type APSObject struct {
 // APSObjectRepository はAPSオブジェクトのリポジトリインターフェース
 type APSObjectRepository interface {
 	GetS3SignedURLs(bucketKey string, objectKey string, parts int) (*APSObject, error)
+	PutS3SignedURLs(signedURL string, fileContent []byte) error
 }
 
 // APSObjectUseCase はAPSオブジェクトのユースケースインターフェース
 type APSObjectUseCase interface {
 	GetS3SignedURLs(bucketKey string, objectKey string, parts int) (*APSObject, error)
+	PutS3SignedURLs(signedURL string, fileContent []byte) error
 }

--- a/backend/internal/infrastructure/aps/aps_object/put_S3_signed_urls.go
+++ b/backend/internal/infrastructure/aps/aps_object/put_S3_signed_urls.go
@@ -1,0 +1,41 @@
+package aps_object
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// PutS3SignedURLs はS3署名付きURLを使用してオブジェクトをアップロードします
+func (r *APSObjectRepository) PutS3SignedURLs(signedURL string, fileContent []byte) error {
+	// リクエストを作成
+	req, err := http.NewRequest("PUT", signedURL, bytes.NewReader(fileContent))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// ヘッダーを設定
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	// リクエストを送信
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// レスポンスを読み取り
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// ステータスコードをチェック
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("API returned non-OK status: %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}

--- a/backend/internal/interface/handler/aps_object/put_S3_signed_urls.go
+++ b/backend/internal/interface/handler/aps_object/put_S3_signed_urls.go
@@ -1,0 +1,56 @@
+package aps_object
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+// @Summary S3署名付きURLを使用したオブジェクトのアップロード
+// @Description S3署名付きURLを使用してオブジェクトをS3へアップロードします
+// @Tags APS Object
+// @Accept octet-stream
+// @Produce json
+// @Param signedURL query string true "署名付きURL"
+// @Param file body []byte true "アップロードするファイルのバイナリデータ"
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /api/v1/aps/objects/signeds3upload [put]
+func (h *APSObjectHandler) PutS3SignedURLs(w http.ResponseWriter, r *http.Request) {
+	// クエリパラメータから署名付きURLを取得
+	signedURL := r.URL.Query().Get("signedURL")
+	if signedURL == "" {
+		http.Error(w, "signed URL is required", http.StatusBadRequest)
+		return
+	}
+
+	// リクエストボディからファイルコンテンツを読み取り
+	fileContent, err := readRequestBody(r)
+	if err != nil {
+		http.Error(w, "failed to read file content: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// ユースケース層に処理を委譲
+	err = h.objectUseCase.PutS3SignedURLs(signedURL, fileContent)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// レスポンスを返す
+	w.Header().Set("Content-Type", "application/json")
+	response := map[string]string{
+		"message": "Upload to S3 using signed URL completed.",
+	}
+	json.NewEncoder(w).Encode(response)
+}
+
+// リクエストボディからファイルコンテンツを読み取るヘルパー関数
+func readRequestBody(r *http.Request) ([]byte, error) {
+	// 最大32MBまでに制限
+	limitedReader := http.MaxBytesReader(nil, r.Body, 32<<20)
+	// リクエストボディを読み取り
+	return io.ReadAll(limitedReader)
+}

--- a/backend/internal/interface/handler/aps_object/upload_aps_object_seq.go
+++ b/backend/internal/interface/handler/aps_object/upload_aps_object_seq.go
@@ -1,0 +1,133 @@
+package aps_object
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/gorilla/mux"
+)
+
+// @Summary APSオブジェクトのアップロードシーケンス
+// @Description S3署名付きURLを取得してオブジェクトをアップロードするシーケンスを実行します
+// @Tags APS Object
+// @Accept multipart/form-data
+// @Produce json
+// @Param bucketKey path string true "バケットキー"
+// @Param file formData file true "アップロードするファイル"
+// @Param parts query int false "パート数" default(1)
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /api/v1/aps/buckets/{bucketKey}/objects/upload [post]
+func (h *APSObjectHandler) UploadAPSObjectSequence(w http.ResponseWriter, r *http.Request) {
+	// URLパラメータからバケットキーを取得
+	vars := mux.Vars(r)
+	bucketKey := vars["bucketKey"]
+	if bucketKey == "" {
+		http.Error(w, "bucket key is required", http.StatusBadRequest)
+		return
+	}
+
+	// クエリパラメータからパート数を取得（デフォルトは1）
+	partsStr := r.URL.Query().Get("parts")
+	parts := 1
+	if partsStr != "" {
+		var err error
+		parts, err = strconv.Atoi(partsStr)
+		if err != nil {
+			http.Error(w, "invalid parts parameter", http.StatusBadRequest)
+			return
+		}
+	}
+
+	// マルチパートフォームを解析（最大32MBまで）
+	err := r.ParseMultipartForm(32 << 20)
+	if err != nil {
+		http.Error(w, "failed to parse multipart form: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// アップロードされたファイルを取得
+	file, handler, err := r.FormFile("file")
+	if err != nil {
+		http.Error(w, "failed to get uploaded file: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+
+	// ファイル名をオブジェクトキーとして使用
+	objectKey := handler.Filename
+	if objectKey == "" {
+		http.Error(w, "file name cannot be empty", http.StatusBadRequest)
+		return
+	}
+
+	// ファイル内容を一時ファイルに保存
+	tempFile, err := saveToTempFile(file, objectKey)
+	if err != nil {
+		http.Error(w, "failed to save file: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer os.Remove(tempFile) // 処理完了後に一時ファイルを削除
+
+	// ステップ1: S3署名付きURLを取得
+	apsObject, err := h.objectUseCase.GetS3SignedURLs(bucketKey, objectKey, parts)
+	if err != nil {
+		http.Error(w, "failed to get signed URLs: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// URLが取得できなかった場合
+	if len(apsObject.URLs) == 0 {
+		http.Error(w, "no signed URLs returned", http.StatusInternalServerError)
+		return
+	}
+
+	// ステップ2: 一時ファイルの内容を読み込み
+	fileContent, err := os.ReadFile(tempFile)
+	if err != nil {
+		http.Error(w, "failed to read temp file: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// ステップ3: S3署名付きURLを使用してファイルをアップロード
+	// 現在の実装では単一パートのみサポート
+	for i, signedURL := range apsObject.URLs {
+		err = h.objectUseCase.PutS3SignedURLs(signedURL, fileContent)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to upload file part %d: %s", i+1, err.Error()), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	// レスポンスを返す
+	w.Header().Set("Content-Type", "application/json")
+	response := map[string]string{
+		"message": "Upload to S3 using signed URL completed.",
+	}
+	json.NewEncoder(w).Encode(response)
+}
+
+// 一時ファイルに保存するヘルパー関数
+func saveToTempFile(src io.Reader, originalName string) (string, error) {
+	// 一時ディレクトリに元のファイル名を使用して一時ファイルを作成
+	ext := filepath.Ext(originalName)
+	tempFile, err := os.CreateTemp("", "upload-*"+ext)
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer tempFile.Close()
+
+	// ファイル内容をコピー
+	_, err = io.Copy(tempFile, src)
+	if err != nil {
+		return "", fmt.Errorf("failed to copy file content: %w", err)
+	}
+
+	return tempFile.Name(), nil
+}

--- a/backend/internal/interface/router/aps_object_router.go
+++ b/backend/internal/interface/router/aps_object_router.go
@@ -9,4 +9,7 @@ import (
 func SetAPSObjectRoutes(router *mux.Router, handler *aps_object.APSObjectHandler) {
 	// S3署名付きURLの取得
 	router.HandleFunc("/api/v1/aps/buckets/{bucketKey}/objects/signeds3upload", handler.GetS3SignedURLs).Methods("POST")
+	
+	// APSオブジェクトのアップロードシーケンス（署名付きURL取得→アップロード）
+	router.HandleFunc("/api/v1/aps/buckets/{bucketKey}/objects/upload", handler.UploadAPSObjectSequence).Methods("POST")
 }

--- a/backend/internal/usecase/aps_object/put_S3_signed_urls.go
+++ b/backend/internal/usecase/aps_object/put_S3_signed_urls.go
@@ -1,0 +1,7 @@
+package aps_object
+
+// PutS3SignedURLs はS3署名付きURLを使用してオブジェクトをアップロードします
+func (u *APSObjectUseCase) PutS3SignedURLs(signedURL string, fileContent []byte) error {
+	// リポジトリ層に処理を委譲
+	return u.objectRepo.PutS3SignedURLs(signedURL, fileContent)
+}


### PR DESCRIPTION
## 変更内容
### S3署名付きURLを使用したオブジェクトアップロード機能の実装
S3署名付きURLを使用したオブジェクトアップロード機能を実装。具体的には以下の機能を追加：

1. S3署名付きURLを使用してオブジェクトをアップロードする機能
2. 署名付きURLの取得からアップロードまでを一連の流れで処理するシーケンス機能
3. Postmanでテストするためのコレクションとドキュメント

## 実装詳細

### 新規ファイル
1. インフラストラクチャ層
   - `backend/internal/infrastructure/aps/aps_object/put_S3_signed_urls.go`：S3署名付きURLを使用したアップロード機能

2. ユースケース層
   - `backend/internal/usecase/aps_object/put_S3_signed_urls.go`：リポジトリ層に処理を委譲

3. インターフェース層（ハンドラー）
   - `backend/internal/interface/handler/aps_object/put_S3_signed_urls.go`：アップロードエンドポイント
   - `backend/internal/interface/handler/aps_object/upload_aps_object_seq.go`：シーケンス処理ハンドラー

4. テスト用ドキュメント
   - `backend/docs/postman_collection.json`：Postmanコレクションファイル
   - `backend/docs/postman_usage.md`：Postmanの使用方法ガイド

### 更新ファイル
1. ドメインモデル
   - `backend/internal/domain/aps_object.go`：インターフェースにPutS3SignedURLsメソッドを追加

2. ルーター
   - `backend/internal/interface/router/aps_object_router.go`：新しいエンドポイントを追加

### 新しいエンドポイント
1. APSオブジェクトのアップロードシーケンス
   - エンドポイント: `POST /api/v1/aps/buckets/{bucketKey}/objects/upload`
   - 機能: 署名付きURLの取得からアップロードまでを一連の流れで処理

## 実装上の注意点
- S3署名付きURLは直接そのURLに対してPUTリクエストを送信する必要がある
- シーケンス処理ハンドラーでは複数パートに対応できるよう実装
- 一時ファイルを使用してアップロードファイルを保存し、処理完了後に削除するように実装

## 関連
Closes #17
