### PR TITLE
feature/backend/base64でエンコードされたURN生成機能の実装

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -408,6 +408,53 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/aps/objects/{objectId}/base64urn": {
+            "get": {
+                "description": "オブジェクトIDをBase64エンコードしたURNを生成します",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "APS Object"
+                ],
+                "summary": "オブジェクトURNのBase64エンコード",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "オブジェクトID",
+                        "name": "objectId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/aps_object.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/aps_object.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/aps/token": {
             "post": {
                 "description": "2-legged認証でAPSアクセストークンを取得します",

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -401,6 +401,53 @@
                 }
             }
         },
+        "/api/v1/aps/objects/{objectId}/base64urn": {
+            "get": {
+                "description": "オブジェクトIDをBase64エンコードしたURNを生成します",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "APS Object"
+                ],
+                "summary": "オブジェクトURNのBase64エンコード",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "オブジェクトID",
+                        "name": "objectId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/aps_object.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/aps_object.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/aps/token": {
             "post": {
                 "description": "2-legged認証でAPSアクセストークンを取得します",

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -309,6 +309,37 @@ paths:
       summary: APSオブジェクトのアップロードシーケンス
       tags:
       - APS Object
+  /api/v1/aps/objects/{objectId}/base64urn:
+    get:
+      consumes:
+      - application/json
+      description: オブジェクトIDをBase64エンコードしたURNを生成します
+      parameters:
+      - description: オブジェクトID
+        in: path
+        name: objectId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/aps_object.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/aps_object.ErrorResponse'
+      summary: オブジェクトURNのBase64エンコード
+      tags:
+      - APS Object
   /api/v1/aps/objects/signeds3upload:
     put:
       consumes:

--- a/backend/internal/domain/aps_object.go
+++ b/backend/internal/domain/aps_object.go
@@ -26,4 +26,5 @@ type APSObjectUseCase interface {
 	GetS3SignedURLs(bucketKey string, objectKey string, parts int) (*APSObject, error)
 	PutS3SignedURLs(signedURL string, fileContent []byte) error
 	CreateObject(bucketKey, objectKey, uploadKey string) (*APSObject, error)  // 追加
+	GenerateBase64EncodedURN(objectId string) (string, error)
 }

--- a/backend/internal/interface/handler/aps_object/generate_base64_encoded_urn.go
+++ b/backend/internal/interface/handler/aps_object/generate_base64_encoded_urn.go
@@ -1,0 +1,35 @@
+package aps_object
+
+import (
+    "encoding/json"
+    "net/http"
+    "github.com/gorilla/mux"
+)
+
+// @Summary オブジェクトURNのBase64エンコード
+// @Description オブジェクトIDをBase64エンコードしたURNを生成します
+// @Tags APS Object
+// @Accept json
+// @Produce json
+// @Param objectId path string true "オブジェクトID"
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /api/v1/aps/objects/{objectId}/base64urn [get]
+func (h *APSObjectHandler) GenerateBase64EncodedURN(w http.ResponseWriter, r *http.Request) {
+    vars := mux.Vars(r)
+    objectId := vars["objectId"]
+    
+    base64URN, err := h.objectUseCase.GenerateBase64EncodedURN(objectId)
+    if err != nil {
+        http.Error(w, err.Error(), http.StatusInternalServerError)
+        return
+    }
+
+    response := map[string]string{
+        "base64EncodedURN": base64URN,
+    }
+
+    w.Header().Set("Content-Type", "application/json")
+    json.NewEncoder(w).Encode(response)
+}

--- a/backend/internal/interface/handler/aps_object/upload_aps_object_seq.go
+++ b/backend/internal/interface/handler/aps_object/upload_aps_object_seq.go
@@ -112,9 +112,21 @@ func (h *APSObjectHandler) UploadAPSObjectSequence(w http.ResponseWriter, r *htt
 		return
 	}
 
-	// レスポンスを更新
+	// Base64エンコードされたURNを生成
+	base64URN, err := h.objectUseCase.GenerateBase64EncodedURN(finalObject.ObjectId)
+	if err != nil {
+		http.Error(w, "failed to generate base64 URN: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// レスポンスに追加
+	response := map[string]interface{}{
+		"object": finalObject,
+		"base64EncodedURN": base64URN,
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(finalObject)
+	json.NewEncoder(w).Encode(response)
 }
 
 // 一時ファイルに保存するヘルパー関数

--- a/backend/internal/interface/router/aps_object_router.go
+++ b/backend/internal/interface/router/aps_object_router.go
@@ -10,10 +10,12 @@ func SetAPSObjectRoutes(router *mux.Router, handler *aps_object.APSObjectHandler
 	// S3署名付きURLの取得
 	router.HandleFunc("/api/v1/aps/buckets/{bucketKey}/objects/signeds3upload", handler.GetS3SignedURLs).Methods("POST")
 	
-	// APSオブジェクトのアップロードシーケンス（署名付きURL取得→アップロード）
 	router.HandleFunc("/api/v1/aps/buckets/{bucketKey}/objects/upload", handler.UploadAPSObjectSequence).Methods("POST")
 	
 	// 既存のルートに追加
 	router.HandleFunc("/api/v1/aps/buckets/{bucketKey}/objects/{objectKey}/signeds3upload", 
 		handler.CreateObject).Methods("POST")
+	
+	// 既存のルーター設定に追加
+	router.HandleFunc("/api/v1/aps/objects/{objectId}/base64urn", handler.GenerateBase64EncodedURN).Methods("GET")
 }

--- a/backend/internal/usecase/aps_object/generate_base64_encoded_urn.go
+++ b/backend/internal/usecase/aps_object/generate_base64_encoded_urn.go
@@ -1,0 +1,17 @@
+package aps_object
+
+import (
+    "encoding/base64"
+    "fmt"
+)
+
+// GenerateBase64EncodedURN はオブジェクトIDからBase64エンコードされたURNを生成します
+func (u *APSObjectUseCase) GenerateBase64EncodedURN(objectId string) (string, error) {
+    // URN形式の文字列を作成
+    urn := fmt.Sprintf("urn:adsk.objects:os.object:%s", objectId)
+    
+    // URL-safe Base64エンコード（パディングなし）を使用
+    base64URN := base64.RawURLEncoding.EncodeToString([]byte(urn))
+    
+    return base64URN, nil
+}


### PR DESCRIPTION
## 変更内容
### Base64エンコードURN生成機能の実装

APSのModel Derivative APIで使用するBase64エンコードURN生成機能を実装しました。

## 主な変更点
- domain/aps_object.go
  - APSObjectUseCaseインターフェースにGenerateBase64EncodedURNメソッドを追加

- usecase/aps_object/generate_base64_encoded_urn.go
  - Base64エンコードURN生成ロジックを実装
  - URN形式: `urn:adsk.objects:os.object:{objectId}`
  - URL-safe Base64エンコード(パディングなし)を使用

- handler/aps_object/generate_base64_encoded_urn.go
  - エンドポイントハンドラーを実装
  - Swaggerドキュメント用アノテーション追加

- router/aps_object_router.go
  - 新規エンドポイント追加: GET /api/v1/aps/objects/{objectId}/base64urn

## 動作確認方法
1. オブジェクトIDを指定してAPIを呼び出し
```bash
curl http://localhost:8080/api/v1/aps/objects/{objectId}/base64urn
```

2. レスポンス例
```json
{
    "base64EncodedURN": "dXJuOmFkc2sub2JqZWN0czpvcy5vYmplY3Q6YnVja2V0L2ZpbGUucnZ0"
}
```

## 関連Issue
close #21
