### PR TITLE
feature/backend/APS Objectの翻訳ジョブステータスの追跡機能の実装

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -506,6 +506,50 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/aps/objects/{urn}/status": {
+            "get": {
+                "description": "翻訳ジョブの進捗状況を確認します",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "APS Object"
+                ],
+                "summary": "翻訳ジョブのステータス確認",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Base64エンコードされたURN",
+                        "name": "urn",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.TranslationStatus"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/aps_object.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/aps_object.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/aps/token": {
             "post": {
                 "description": "2-legged認証でAPSアクセストークンを取得します",
@@ -653,6 +697,93 @@ const docTemplate = `{
                 }
             }
         },
+        "domain.Children": {
+            "type": "object",
+            "properties": {
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Resource"
+                    }
+                },
+                "guid": {
+                    "type": "string"
+                },
+                "hasThumbnail": {
+                    "type": "string"
+                },
+                "messages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Message"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "progress": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.Derivative": {
+            "type": "object",
+            "properties": {
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Children"
+                    }
+                },
+                "hasThumbnail": {
+                    "type": "string"
+                },
+                "messages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Message"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "outputType": {
+                    "type": "string"
+                },
+                "progress": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.Message": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.Permission": {
             "type": "object",
             "properties": {
@@ -660,6 +791,32 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "authId": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.Resource": {
+            "type": "object",
+            "properties": {
+                "guid": {
+                    "type": "string"
+                },
+                "mime": {
+                    "type": "string"
+                },
+                "resolution": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "role": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "urn": {
                     "type": "string"
                 }
             }
@@ -695,6 +852,35 @@ const docTemplate = `{
                     }
                 },
                 "result": {
+                    "type": "string"
+                },
+                "urn": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.TranslationStatus": {
+            "type": "object",
+            "properties": {
+                "derivatives": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Derivative"
+                    }
+                },
+                "hasThumbnail": {
+                    "type": "string"
+                },
+                "progress": {
+                    "type": "string"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "type": {
                     "type": "string"
                 },
                 "urn": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -499,6 +499,50 @@
                 }
             }
         },
+        "/api/v1/aps/objects/{urn}/status": {
+            "get": {
+                "description": "翻訳ジョブの進捗状況を確認します",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "APS Object"
+                ],
+                "summary": "翻訳ジョブのステータス確認",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Base64エンコードされたURN",
+                        "name": "urn",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.TranslationStatus"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/aps_object.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/aps_object.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/aps/token": {
             "post": {
                 "description": "2-legged認証でAPSアクセストークンを取得します",
@@ -646,6 +690,93 @@
                 }
             }
         },
+        "domain.Children": {
+            "type": "object",
+            "properties": {
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Resource"
+                    }
+                },
+                "guid": {
+                    "type": "string"
+                },
+                "hasThumbnail": {
+                    "type": "string"
+                },
+                "messages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Message"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "progress": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.Derivative": {
+            "type": "object",
+            "properties": {
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Children"
+                    }
+                },
+                "hasThumbnail": {
+                    "type": "string"
+                },
+                "messages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Message"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "outputType": {
+                    "type": "string"
+                },
+                "progress": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.Message": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.Permission": {
             "type": "object",
             "properties": {
@@ -653,6 +784,32 @@
                     "type": "string"
                 },
                 "authId": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.Resource": {
+            "type": "object",
+            "properties": {
+                "guid": {
+                    "type": "string"
+                },
+                "mime": {
+                    "type": "string"
+                },
+                "resolution": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "role": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "urn": {
                     "type": "string"
                 }
             }
@@ -688,6 +845,35 @@
                     }
                 },
                 "result": {
+                    "type": "string"
+                },
+                "urn": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.TranslationStatus": {
+            "type": "object",
+            "properties": {
+                "derivatives": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Derivative"
+                    }
+                },
+                "hasThumbnail": {
+                    "type": "string"
+                },
+                "progress": {
+                    "type": "string"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "type": {
                     "type": "string"
                 },
                 "urn": {

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -74,11 +74,85 @@ definitions:
         example: Bearer
         type: string
     type: object
+  domain.Children:
+    properties:
+      children:
+        items:
+          $ref: '#/definitions/domain.Resource'
+        type: array
+      guid:
+        type: string
+      hasThumbnail:
+        type: string
+      messages:
+        items:
+          $ref: '#/definitions/domain.Message'
+        type: array
+      name:
+        type: string
+      progress:
+        type: string
+      role:
+        type: string
+      status:
+        type: string
+      type:
+        type: string
+    type: object
+  domain.Derivative:
+    properties:
+      children:
+        items:
+          $ref: '#/definitions/domain.Children'
+        type: array
+      hasThumbnail:
+        type: string
+      messages:
+        items:
+          $ref: '#/definitions/domain.Message'
+        type: array
+      name:
+        type: string
+      outputType:
+        type: string
+      progress:
+        type: string
+      status:
+        type: string
+    type: object
+  domain.Message:
+    properties:
+      code:
+        type: string
+      message:
+        items:
+          type: string
+        type: array
+      type:
+        type: string
+    type: object
   domain.Permission:
     properties:
       access:
         type: string
       authId:
+        type: string
+    type: object
+  domain.Resource:
+    properties:
+      guid:
+        type: string
+      mime:
+        type: string
+      resolution:
+        items:
+          type: number
+        type: array
+      role:
+        type: string
+      type:
+        type: string
+      urn:
         type: string
     type: object
   domain.TranslateJobResponse:
@@ -101,6 +175,25 @@ definitions:
             type: object
         type: object
       result:
+        type: string
+      urn:
+        type: string
+    type: object
+  domain.TranslationStatus:
+    properties:
+      derivatives:
+        items:
+          $ref: '#/definitions/domain.Derivative'
+        type: array
+      hasThumbnail:
+        type: string
+      progress:
+        type: string
+      region:
+        type: string
+      status:
+        type: string
+      type:
         type: string
       urn:
         type: string
@@ -396,6 +489,35 @@ paths:
           schema:
             $ref: '#/definitions/aps_object.ErrorResponse'
       summary: APSオブジェクトの翻訳ジョブ作成
+      tags:
+      - APS Object
+  /api/v1/aps/objects/{urn}/status:
+    get:
+      consumes:
+      - application/json
+      description: 翻訳ジョブの進捗状況を確認します
+      parameters:
+      - description: Base64エンコードされたURN
+        in: path
+        name: urn
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/domain.TranslationStatus'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/aps_object.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/aps_object.ErrorResponse'
+      summary: 翻訳ジョブのステータス確認
       tags:
       - APS Object
   /api/v1/aps/objects/signeds3upload:

--- a/backend/internal/domain/aps_object.go
+++ b/backend/internal/domain/aps_object.go
@@ -22,6 +22,8 @@ type APSObjectRepository interface {
 	GenerateBase64EncodedURN(objectId string) (string, error)
 	// 新規追加
 	TranslateObject(base64URN string, objectKey string) (*TranslateJobResponse, error)
+	// 追加
+	TrackTranslationJobStatus(urn string) (*TranslationStatus, error)
 }
 
 // APSObjectUseCase はAPSオブジェクトのユースケースインターフェース
@@ -32,6 +34,8 @@ type APSObjectUseCase interface {
 	GenerateBase64EncodedURN(objectId string) (string, error)
 	// 新規追加
 	TranslateObject(base64URN string, objectKey string) (*TranslateJobResponse, error)
+	// 追加
+	TrackTranslationJobStatus(urn string) (*TranslationStatus, error)
 }
 
 type TranslateJobResponse struct {

--- a/backend/internal/domain/translation_status.go
+++ b/backend/internal/domain/translation_status.go
@@ -1,0 +1,48 @@
+package domain
+
+type TranslationStatus struct {
+    Type         string       `json:"type"`
+    HasThumbnail string      `json:"hasThumbnail"`
+    Status       string      `json:"status"`
+    Progress     string      `json:"progress"`
+    Region       string      `json:"region"`
+    URN          string      `json:"urn"`
+    Derivatives  []Derivative `json:"derivatives"`
+}
+
+type Derivative struct {
+    Name         string     `json:"name"`
+    HasThumbnail string     `json:"hasThumbnail"`
+    Status       string     `json:"status"`
+    Progress     string     `json:"progress"`
+    OutputType   string     `json:"outputType"`
+    Children     []Children `json:"children"`
+    Messages     []Message  `json:"messages,omitempty"`
+}
+
+type Children struct {
+    GUID         string     `json:"guid"`
+    Type         string     `json:"type"`
+    Role         string     `json:"role"`
+    Name         string     `json:"name"`
+    Status       string     `json:"status"`
+    Progress     string     `json:"progress"`
+    HasThumbnail string     `json:"hasThumbnail"`
+    Children     []Resource `json:"children,omitempty"`
+    Messages     []Message  `json:"messages,omitempty"`
+}
+
+type Resource struct {
+    GUID       string    `json:"guid"`
+    Type       string    `json:"type"`
+    URN        string    `json:"urn,omitempty"`
+    Role       string    `json:"role"`
+    Mime       string    `json:"mime"`
+    Resolution []float64 `json:"resolution,omitempty"`
+}
+
+type Message struct {
+    Type    string   `json:"type"`
+    Code    string   `json:"code"`
+    Message []string `json:"message,omitempty"`
+}

--- a/backend/internal/infrastructure/aps/aps_object/track_translation_job_status.go
+++ b/backend/internal/infrastructure/aps/aps_object/track_translation_job_status.go
@@ -1,0 +1,38 @@
+package aps_object
+
+import (
+    "encoding/json"
+    "fmt"
+    "net/http"
+    "github.com/maixhashi/nextgo-aps-viewer/backend/internal/domain"
+)
+
+func (r *APSObjectRepository) TrackTranslationJobStatus(urn string) (*domain.TranslationStatus, error) {
+    token, err := r.tokenRepo.GetToken()
+    if err != nil {
+        return nil, fmt.Errorf("failed to get access token: %w", err)
+    }
+
+    req, err := http.NewRequest("GET", 
+        fmt.Sprintf("https://developer.api.autodesk.com/modelderivative/v2/designdata/%s/manifest", urn),
+        nil)
+    if err != nil {
+        return nil, fmt.Errorf("failed to create request: %w", err)
+    }
+
+    req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    if err != nil {
+        return nil, fmt.Errorf("failed to send request: %w", err)
+    }
+    defer resp.Body.Close()
+
+    var status domain.TranslationStatus
+    if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+        return nil, fmt.Errorf("failed to decode response: %w", err)
+    }
+
+    return &status, nil
+}

--- a/backend/internal/interface/handler/aps_object/track_translation_job_status.go
+++ b/backend/internal/interface/handler/aps_object/track_translation_job_status.go
@@ -1,0 +1,31 @@
+package aps_object
+
+import (
+    "encoding/json"
+    "net/http"
+    "github.com/gorilla/mux"
+)
+
+// @Summary 翻訳ジョブのステータス確認
+// @Description 翻訳ジョブの進捗状況を確認します
+// @Tags APS Object
+// @Accept json
+// @Produce json
+// @Param urn path string true "Base64エンコードされたURN"
+// @Success 200 {object} domain.TranslationStatus
+// @Failure 400 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /api/v1/aps/objects/{urn}/status [get]
+func (h *APSObjectHandler) TrackTranslationJobStatus(w http.ResponseWriter, r *http.Request) {
+    vars := mux.Vars(r)
+    urn := vars["urn"]
+
+    status, err := h.objectUseCase.TrackTranslationJobStatus(urn)
+    if err != nil {
+        http.Error(w, err.Error(), http.StatusInternalServerError)
+        return
+    }
+
+    w.Header().Set("Content-Type", "application/json")
+    json.NewEncoder(w).Encode(status)
+}

--- a/backend/internal/interface/handler/aps_object/upload_aps_object_seq.go
+++ b/backend/internal/interface/handler/aps_object/upload_aps_object_seq.go
@@ -126,11 +126,20 @@ func (h *APSObjectHandler) UploadAPSObjectSequence(w http.ResponseWriter, r *htt
 		return
 	}
 
+	// ステップ6: 翻訳ジョブのステータスを確認
+	// 初回のステータス確認
+	translationStatus, err := h.objectUseCase.TrackTranslationJobStatus(base64URN)
+	if err != nil {
+		http.Error(w, "failed to track translation status: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	// レスポンスに追加
 	response := map[string]interface{}{
-		"object": finalObject,
+		"object":           finalObject,
 		"base64EncodedURN": base64URN,
-		"translateJob": translateResponse,
+		"translateJob":     translateResponse,
+		"translationStatus": translationStatus,  // 翻訳ステータスを追加
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/backend/internal/interface/router/aps_object_router.go
+++ b/backend/internal/interface/router/aps_object_router.go
@@ -18,4 +18,8 @@ func SetAPSObjectRoutes(router *mux.Router, handler *aps_object.APSObjectHandler
 	
 	// 既存のルーター設定に追加
 	router.HandleFunc("/api/v1/aps/objects/{objectId}/base64urn", handler.GenerateBase64EncodedURN).Methods("GET")
+
+	// 翻訳ステータス確認エンドポイントを追加
+	router.HandleFunc("/api/v1/aps/objects/{urn}/status", 
+		handler.TrackTranslationJobStatus).Methods("GET")
 }

--- a/backend/internal/usecase/aps_object/track_translation_job_status.go
+++ b/backend/internal/usecase/aps_object/track_translation_job_status.go
@@ -1,0 +1,9 @@
+package aps_object
+
+import (
+    "github.com/maixhashi/nextgo-aps-viewer/backend/internal/domain"
+)
+
+func (u *APSObjectUseCase) TrackTranslationJobStatus(urn string) (*domain.TranslationStatus, error) {
+    return u.objectRepo.TrackTranslationJobStatus(urn)
+}


### PR DESCRIPTION
## 変更内容
### APS Objectの翻訳ジョブステータスチェック機能の実装
翻訳ジョブのステータスを確認するための機能を実装。

## 主な変更点
- TranslationStatus関連の構造体を追加
  - TranslationStatus
  - Derivative
  - Children
  - Resource
  - Message

- APSObjectRepository/UseCaseインターフェースに新メソッドを追加
  - TrackTranslationJobStatus

- 新規エンドポイントの追加
  - GET `/api/v1/aps/objects/{urn}/status`

- 各レイヤーでの実装
  - インフラストラクチャ層: APS APIとの通信処理
  - ユースケース層: ビジネスロジック
  - インターフェース層: HTTPハンドリング
  - ルーティング設定

## 技術的な詳細
- APS Model Derivative APIを使用して翻訳ステータスを取得
- エラーハンドリングの実装
- JSONレスポンスのマッピング
- アクセストークンの適切な使用

## 動作確認項目
- 正常系
  - 翻訳中のジョブのステータス取得
  - 完了したジョブのステータス取得
- 異常系
  - 無効なURNの場合のエラーハンドリング
  - APIエラー時の適切なエラーレスポンス

## 関連
close #25

## 関連ドキュメント
- [APS Model Derivative API Documentation](https://aps.autodesk.com/en/docs/model-derivative/v2/tutorials/translate-to-obj/task3-translate-source-file/#step-2-check-the-status-of-the-translation-job)
