### PR TITLE
feature/frontend/APS Viewerに描画するためのファイルアップロードフォームの実装

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -5,6 +5,7 @@ import (
     "net/http"
     "os"
 
+    "github.com/gorilla/handlers"
     "github.com/joho/godotenv"
     _ "github.com/maixhashi/nextgo-aps-viewer/backend/docs" // Swaggerドキュメントのインポート
     "github.com/maixhashi/nextgo-aps-viewer/backend/internal/interface/router"
@@ -23,6 +24,11 @@ func main() {
     // ルーターの初期化
     r := router.NewRouter()
 
+    // CORS設定
+    corsOrigins := handlers.AllowedOrigins([]string{"*"})
+    corsHeaders := handlers.AllowedHeaders([]string{"X-Requested-With", "Content-Type", "Authorization"})
+    corsMethods := handlers.AllowedMethods([]string{"GET", "POST", "PUT", "DELETE", "OPTIONS"})
+    
     // サーバーの起動
     port := os.Getenv("PORT")
     if port == "" {
@@ -30,5 +36,5 @@ func main() {
     }
     
     log.Printf("Server starting on port %s", port)
-    log.Fatal(http.ListenAndServe(":"+port, r))
+    log.Fatal(http.ListenAndServe(":"+port, handlers.CORS(corsOrigins, corsHeaders, corsMethods)(r)))
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/bytedance/sonic/loader v0.1.1 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
+	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/gin-gonic/gin v1.10.1 // indirect
@@ -27,6 +28,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.20.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/gorilla/handlers v1.5.2 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -12,6 +12,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
+github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
@@ -39,6 +41,8 @@ github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MG
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE=
+github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=

--- a/frontend/src/app/aps-viewer/page.tsx
+++ b/frontend/src/app/aps-viewer/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import Head from "next/head";
 import { APSViewer } from "@/features/aps/components/APSViewer";
+import { FileUploader } from "@/features/aps/components/FileUploader";
 import { useAPSViewerStore } from "@/store/apsViewerStore";
 
 export default function APSViewerPage() {
@@ -36,12 +37,24 @@ export default function APSViewerPage() {
   }, [fetchConfig]);
 
   return (
-    <>
+    <div className="flex flex-col h-screen">
+      {/* ヘッダー */}
+      <header className="bg-gray-800 text-white p-4">
+        <h1 className="text-2xl font-bold">APS Viewer</h1>
+      </header>
       
-      {/* ビューワーコンテナ */}
-      <div className="w-full h-screen">
-        <APSViewer />
+      {/* メインコンテンツ */}
+      <div className="flex flex-col md:flex-row flex-1 overflow-hidden">
+        {/* サイドバー - ファイルアップローダー */}
+        <div className="w-full md:w-1/3 p-4 overflow-y-auto bg-gray-100">
+          <FileUploader />
+        </div>
+        
+        {/* ビューワーコンテナ */}
+        <div className="w-full md:w-2/3 h-full">
+          <APSViewer />
+        </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/frontend/src/features/aps/api/useAPSToken.ts
+++ b/frontend/src/features/aps/api/useAPSToken.ts
@@ -18,7 +18,22 @@ export function useAPSToken() {
   return useQuery({
     queryKey: APS_TOKEN_QUERY_KEY,
     queryFn: async () => {
-      return apiClient.get<APSTokenResponse>('/api/aps/token');
+      const url = `http://localhost:8080/api/v1/aps/token`;
+      
+      const response = await fetch(url, {
+        method: 'POST',
+      });
+      
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(
+          `API リクエストエラー: ${response.status} ${response.statusText} - ${
+            JSON.stringify(errorData)
+          }`
+        );
+      }
+      
+      return await response.json();
     },
     // トークンの有効期限は通常3600秒（1時間）なので、
     // 50分（3000秒）経過したらリフェッチする

--- a/frontend/src/features/aps/api/useAPSUpload.ts
+++ b/frontend/src/features/aps/api/useAPSUpload.ts
@@ -1,0 +1,122 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/shared/lib/api/apiClient';
+
+interface UploadAPSObjectResponse {
+  object: {
+    objectId: string;
+    objectKey: string;
+    size: number;
+    location: string;
+  };
+  base64EncodedURN: string;
+  translateJob: {
+    result: string;
+  };
+  translationStatus: {
+    status: string;
+    progress: string;
+  };
+}
+
+export const useAPSUpload = () => {
+  return useMutation({
+    mutationFn: async ({ file, bucketKey }: { file: File; bucketKey: string }) => {
+      const formData = new FormData();
+      formData.append('file', file);
+
+      // FormDataを使用する場合、apiClientの実装を修正
+      // fetchAPIを直接使用して、Content-Typeヘッダーを自動設定させる
+      const url = `http://localhost:8080/api/v1/aps/buckets/${bucketKey}/objects/upload`;
+      
+      const response = await fetch(url, {
+        method: 'POST',
+        body: formData,
+        // Content-Typeヘッダーは自動設定されるので指定しない
+      });
+      
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(
+          `API リクエストエラー: ${response.status} ${response.statusText} - ${
+            JSON.stringify(errorData)
+          }`
+        );
+      }
+      
+      return await response.json();
+    },
+  });
+};
+
+// バケット作成用のAPI
+interface CreateBucketResponse {
+  bucketKey: string;
+  bucketOwner: string;
+  createdDate: number;
+  permissions: Array<{
+    authId: string;
+    access: string;
+  }>;
+  policyKey: string;
+}
+
+export const useCreateBucket = () => {
+  return useMutation({
+    mutationFn: async ({ bucketKey, policyKey = 'transient' }: { bucketKey: string; policyKey?: string }) => {
+      const url = `http://localhost:8080/api/v1/aps/buckets`;
+      
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          bucketKey,
+          policyKey,
+        }),
+      });
+      
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(
+          `API リクエストエラー: ${response.status} ${response.statusText} - ${
+            JSON.stringify(errorData)
+          }`
+        );
+      }
+      
+      return await response.json();
+    },
+  });
+};
+
+// バケット一覧取得用のAPI
+interface GetBucketsResponse {
+  items: Array<{
+    bucketKey: string;
+    createdDate: number;
+    policyKey: string;
+  }>;
+}
+
+export const useGetBuckets = () => {
+  return useQuery<GetBucketsResponse>({
+    queryKey: ['buckets'],
+    queryFn: async () => {
+      const url = `http://localhost:8080/api/v1/aps/buckets`;
+      
+      const response = await fetch(url);
+      
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(
+          `API リクエストエラー: ${response.status} ${response.statusText} - ${
+            JSON.stringify(errorData)
+          }`
+        );
+      }
+      
+      return await response.json();
+    },
+  });
+};

--- a/frontend/src/features/aps/components/FileUploader.tsx
+++ b/frontend/src/features/aps/components/FileUploader.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useState, useRef, ChangeEvent } from 'react';
+import { useAPSViewerStore } from '@/store/apsViewerStore';
+import { useAPSUpload, useCreateBucket, useGetBuckets } from '../api/useAPSUpload';
+import { useAPSToken } from '../api/useAPSToken';
+
+export function FileUploader() {
+  const [file, setFile] = useState<File | null>(null);
+  const [customBucketKey, setCustomBucketKey] = useState<string>('');
+  const [isCreatingBucket, setIsCreatingBucket] = useState<boolean>(false);
+  const [selectedBucketKey, setSelectedBucketKey] = useState<string>('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  
+  const { setUrn, setAccessToken, setLoading, setError } = useAPSViewerStore();
+  const { data: tokenData } = useAPSToken();
+  const { data: bucketsData, refetch: refetchBuckets } = useGetBuckets();
+  const uploadMutation = useAPSUpload();
+  const createBucketMutation = useCreateBucket();
+
+  // ファイル選択ハンドラー
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      setFile(e.target.files[0]);
+    }
+  };
+
+  // バケット作成ハンドラー
+  const handleCreateBucket = async () => {
+    if (!customBucketKey) {
+      setError('バケットキーを入力してください');
+      return;
+    }
+
+    try {
+      setLoading(true);
+      await createBucketMutation.mutateAsync({ bucketKey: customBucketKey });
+      setCustomBucketKey('');
+      setIsCreatingBucket(false);
+      refetchBuckets();
+    } catch (error) {
+      console.error('バケット作成エラー:', error);
+      setError(`バケット作成に失敗しました: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // ファイルアップロードハンドラー
+  const handleUpload = async () => {
+    if (!file) {
+      setError('ファイルを選択してください');
+      return;
+    }
+
+    if (!selectedBucketKey) {
+      setError('バケットを選択してください');
+      return;
+    }
+
+    try {
+      setLoading(true);
+      const result = await uploadMutation.mutateAsync({
+        file,
+        bucketKey: selectedBucketKey,
+      });
+
+      // アップロード成功後、URNをセット
+      if (result.base64EncodedURN) {
+        // URNをセット（内部でアクセストークンも取得される）
+        setUrn(result.base64EncodedURN);
+        
+        // トークンデータがあれば、アクセストークンも直接セット
+        if (tokenData?.access_token) {
+          setAccessToken(tokenData.access_token);
+        }
+        
+        console.log('モデル変換ジョブが開始されました:', result);
+      } else {
+        setError('URNの取得に失敗しました');
+      }
+    } catch (error) {
+      console.error('ファイルアップロードエラー:', error);
+      setError(`ファイルアップロードに失敗しました: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-4 bg-white rounded-lg shadow-md">
+      <h2 className="text-xl font-bold mb-4">ファイルアップロード</h2>
+      
+      {/* バケット選択/作成セクション */}
+      <div className="mb-4">
+        <h3 className="text-lg font-semibold mb-2">バケット選択</h3>
+        
+        {/* 既存バケット選択 */}
+        <div className="mb-2">
+          <select
+            className="w-full p-2 border rounded"
+            value={selectedBucketKey}
+            onChange={(e) => setSelectedBucketKey(e.target.value)}
+          >
+            <option value="">バケットを選択</option>
+            {bucketsData?.items?.map((bucket) => (
+              <option key={bucket.bucketKey} value={bucket.bucketKey}>
+                {bucket.bucketKey}
+              </option>
+            ))}
+          </select>
+        </div>
+        
+        {/* 新規バケット作成 */}
+        {isCreatingBucket ? (
+          <div className="flex space-x-2">
+            <input
+              type="text"
+              className="flex-1 p-2 border rounded"
+              placeholder="新しいバケットキー"
+              value={customBucketKey}
+              onChange={(e) => setCustomBucketKey(e.target.value)}
+            />
+            <button
+              className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+              onClick={handleCreateBucket}
+            >
+              作成
+            </button>
+            <button
+              className="px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400"
+              onClick={() => setIsCreatingBucket(false)}
+            >
+              キャンセル
+            </button>
+          </div>
+        ) : (
+          <button
+            className="px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600"
+            onClick={() => setIsCreatingBucket(true)}
+          >
+            新規バケット作成
+          </button>
+        )}
+      </div>
+      
+      {/* ファイル選択セクション */}
+      <div className="mb-4">
+        <h3 className="text-lg font-semibold mb-2">ファイル選択</h3>
+        <div className="flex items-center space-x-2">
+          <input
+            type="file"
+            ref={fileInputRef}
+            className="hidden"
+            onChange={handleFileChange}
+            accept=".rvt,.rfa,.dwg,.nwd,.3dm,.ipt,.iam,.sldprt,.sldasm,.step,.stp,.stl,.obj"
+          />
+          <button
+            className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+            onClick={() => fileInputRef.current?.click()}
+          >
+            ファイルを選択
+          </button>
+          <span className="text-gray-600">
+            {file ? file.name : 'ファイルが選択されていません'}
+          </span>
+        </div>
+        <p className="text-sm text-gray-500 mt-1">
+          サポートされているファイル形式: .rvt, .rfa, .dwg, .nwd, .3dm, .ipt, .iam, .sldprt, .sldasm, .step, .stp, .stl, .obj
+        </p>
+      </div>
+      
+      {/* アップロードボタン */}
+      <button
+        className="w-full px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600 disabled:bg-gray-300 disabled:cursor-not-allowed"
+        onClick={handleUpload}
+        disabled={!file || !selectedBucketKey || uploadMutation.isPending}
+      >
+        {uploadMutation.isPending ? 'アップロード中...' : 'アップロード'}
+      </button>
+      
+      {/* エラーメッセージ */}
+      {uploadMutation.error && (
+        <div className="mt-2 p-2 bg-red-100 text-red-700 rounded">
+          {uploadMutation.error instanceof Error
+            ? uploadMutation.error.message
+            : 'アップロード中にエラーが発生しました'}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要
### APS Viewerに描画するためのファイルアップロードフォームの実装
フロントエンド上で任意のファイル（.rvtファイルなど）をアップロードし、
バックエンドでの処理を経て、APSビューワーで3Dモデルを表示する機能を実装。

## 目的
- ユーザーがブラウザから直接3Dモデルファイルをアップロードできるようにする
- アップロードしたファイルをAPS（Autodesk Platform Services）で処理し、ビューワーに表示する
- バケット作成からファイル変換までの一連のフローを自動化する

## 実装内容
- バックエンドのCORS設定追加
- フロントエンドにファイルアップロードコンポーネント作成
- バケット作成・選択機能
- ファイルアップロード機能
- アップロードしたファイルのURNをAPSビューワーに渡す機能
- APIリクエスト処理の改善

## 技術的な詳細
- バックエンド：gorilla/handlersを使用したCORS設定
- フロントエンド：React Hooksを使用したファイルアップロードコンポーネント
- API連携：FormDataを使用したファイルアップロード
- 状態管理：Zustandを使用したURNとアクセストークンの管理

## 関連
close #33 

## 関連資料
- [APS Model Derivative API](https://aps.autodesk.com/en/docs/model-derivative/v2/reference/http/jobs/job-POST/)
- [APS Viewer Documentation](https://aps.autodesk.com/en/docs/viewer/v7/developers_guide/viewer_basics/viewer-app/)
