### PR TITLE
feature/frontend/React Three Fiber Viewerのメッシュモデルの要素の変形操作機能の実装

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "react-dom": "^19.0.0",
         "tailwind-merge": "^3.3.1",
         "three": "^0.177.0",
+        "valtio": "^2.1.5",
         "zod": "^3.25.64",
         "zustand": "^5.0.5"
       },
@@ -9775,6 +9776,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/proxy-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
+      "integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -11807,6 +11814,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/valtio": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/valtio/-/valtio-2.1.5.tgz",
+      "integrity": "sha512-vsh1Ixu5mT0pJFZm+Jspvhga5GzHUTYv0/+Th203pLfh3/wbHwxhu/Z2OkZDXIgHfjnjBns7SN9HNcbDvPmaGw==",
+      "license": "MIT",
+      "dependencies": {
+        "proxy-compare": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.3.1",
     "three": "^0.177.0",
+    "valtio": "^2.1.5",
     "zod": "^3.25.64",
     "zustand": "^5.0.5"
   },

--- a/frontend/src/features/aps/components/ThreeViewer/DebugPanel.tsx
+++ b/frontend/src/features/aps/components/ThreeViewer/DebugPanel.tsx
@@ -1,41 +1,25 @@
 'use client';
 
-import { ExtractedMeshData } from './types';
-
 interface DebugPanelProps {
-  meshData: ExtractedMeshData[];
-  selectedElement: ExtractedMeshData | null;
+  meshData: any[];
+  selectedElement: any;
 }
 
 export function DebugPanel({ meshData, selectedElement }: DebugPanelProps) {
   // 開発環境でのみ表示
-  if (process.env.NODE_ENV !== 'development' || meshData.length === 0) {
+  if (process.env.NODE_ENV !== 'development') {
     return null;
   }
 
   return (
-    <div className="absolute top-20 left-4 bg-black/70 text-white p-3 rounded z-10 max-w-sm text-xs">
-      <div className="text-sm mb-2">Debug Info</div>
+    <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 bg-black/80 text-white p-3 rounded-lg text-xs z-30 max-w-md">
+      <div className="font-semibold mb-2">Debug Info</div>
       <div className="space-y-1">
-        <div>Rendered meshes: {meshData.length}</div>
-        <div>With geometry: {meshData.filter(m => m.geometryData?.vertices?.length > 0).length}</div>
-        <div>With indices: {meshData.filter(m => m.geometryData?.indices?.length > 0).length}</div>
-        <div>With normals: {meshData.filter(m => m.geometryData?.normals?.length > 0).length}</div>
-        <div>Total vertices: {meshData.reduce((sum, m) => sum + (m.geometryData?.vertexCount || 0), 0)}</div>
-        <div>Total triangles: {meshData.reduce((sum, m) => {
-          if (m.geometryData?.indices) {
-            return sum + Math.floor(m.geometryData.indices.length / 3);
-          }
-          return sum + Math.floor((m.geometryData?.vertexCount || 0) / 3);
-        }, 0)}</div>
+        <div>Total Meshes: {meshData.length}</div>
+        <div>Selected ID: {selectedElement?.dbId || 'None'}</div>
+        <div>Selected Fragment: {selectedElement?.fragId || 'None'}</div>
         {selectedElement && (
-          <div className="mt-2 p-2 bg-yellow-900/50 rounded">
-            <div className="font-semibold">Selected Debug:</div>
-            <div>FragId: {selectedElement.fragId}</div>
-            <div>Vertices: {selectedElement.geometryData.vertexCount}</div>
-            <div>Has Matrix: {!!selectedElement.matrixWorld}</div>
-            <div>Has ElementInfo: {!!selectedElement.elementInfo}</div>
-          </div>
+          <div>Has Element Info: {selectedElement.elementInfo ? 'Yes' : 'No'}</div>
         )}
       </div>
     </div>

--- a/frontend/src/features/aps/components/ThreeViewer/ExtractedMeshes.tsx
+++ b/frontend/src/features/aps/components/ThreeViewer/ExtractedMeshes.tsx
@@ -2,8 +2,10 @@
 
 import { useEffect, useRef } from 'react';
 import * as THREE from 'three';
+import { useSnapshot } from 'valtio';
 import { SelectableMesh } from './SelectableMesh';
 import { ExtractedMeshesProps } from './types';
+import { transformState } from './store/transformStore';
 
 export function ExtractedMeshes({ 
   meshData, 
@@ -14,17 +16,52 @@ export function ExtractedMeshes({
   onUnhover 
 }: ExtractedMeshesProps) {
   const groupRef = useRef<THREE.Group>(null);
+  const snap = useSnapshot(transformState);
 
   useEffect(() => {
     if (!groupRef.current || !meshData || meshData.length === 0) return;
 
-    console.log('=== ThreeViewer: Processing selectable mesh data ===');
+    console.log('=== ExtractedMeshes: Processing mesh data ===');
     console.log('Mesh data count:', meshData.length);
+    console.log('Selected element:', selectedElement?.dbId);
+    console.log('Transform selected:', snap.selectedElement?.dbId);
 
-    // 既存のメッシュをクリア
-    while (groupRef.current.children.length > 0) {
-      const child = groupRef.current.children[0];
-      groupRef.current.remove(child);
+    // 選択されたメッシュのIDを取得（両方の状態をチェック）
+    const selectedMeshIds = new Set<string>();
+    
+    if (selectedElement) {
+      selectedMeshIds.add(`${selectedElement.dbId}-${selectedElement.fragId}`);
+    }
+    
+    if (snap.selectedElement) {
+      selectedMeshIds.add(`${snap.selectedElement.dbId}-${snap.selectedElement.fragId}`);
+    }
+
+    // 既存の子要素をチェック - 選択されたメッシュは絶対に削除しない
+    const childrenToRemove: THREE.Object3D[] = [];
+    groupRef.current.children.forEach(child => {
+      const childMeshId = child.name ? child.name.replace('mesh-', '') : '';
+      
+      if (selectedMeshIds.has(childMeshId)) {
+        console.log('PRESERVING selected mesh in scene:', child.name);
+        // 選択されたメッシュは絶対に保持
+      } else {
+        // 現在のメッシュデータに存在しない場合のみ削除対象に
+        const existsInCurrentData = meshData.some(mesh => 
+          `${mesh.dbId}-${mesh.fragId}` === childMeshId
+        );
+        
+        if (!existsInCurrentData) {
+          childrenToRemove.push(child);
+        }
+      }
+    });
+
+    // 選択されていない、かつ現在のデータに存在しないメッシュのみ削除
+    childrenToRemove.forEach(child => {
+      console.log('Removing unused mesh:', child.name);
+      groupRef.current?.remove(child);
+      
       if (child instanceof THREE.Group) {
         child.children.forEach(mesh => {
           if (mesh instanceof THREE.Mesh) {
@@ -37,24 +74,31 @@ export function ExtractedMeshes({
           }
         });
       }
-    }
+    });
 
-    console.log(`Creating ${meshData.length} selectable meshes`);
-  }, [meshData]);
+    console.log(`ExtractedMeshes: Cleaned up ${childrenToRemove.length} meshes, preserved selected meshes`);
+  }, [meshData, selectedElement, snap.selectedElement]);
 
   return (
     <group ref={groupRef}>
-      {meshData.map((mesh, index) => (
-        <SelectableMesh
-          key={`${mesh.dbId}-${mesh.fragId}`}
-          meshData={mesh}
-          isSelected={selectedElement?.dbId === mesh.dbId && selectedElement?.fragId === mesh.fragId}
-          isHovered={hoveredElement?.dbId === mesh.dbId && hoveredElement?.fragId === mesh.fragId}
-          onSelect={onSelect}
-          onHover={onHover}
-          onUnhover={onUnhover}
-        />
-      ))}
+      {meshData.map((mesh, index) => {
+        const isLocalSelected = selectedElement?.dbId === mesh.dbId && selectedElement?.fragId === mesh.fragId;
+        const isTransformSelected = snap.selectedElement?.dbId === mesh.dbId && snap.selectedElement?.fragId === mesh.fragId;
+        const isSelected = isLocalSelected || isTransformSelected;
+        const isHovered = hoveredElement?.dbId === mesh.dbId && hoveredElement?.fragId === mesh.fragId;
+
+        return (
+          <SelectableMesh
+            key={`${mesh.dbId}-${mesh.fragId}`}
+            meshData={mesh}
+            isSelected={isSelected}
+            isHovered={isHovered}
+            onSelect={onSelect}
+            onHover={onHover}
+            onUnhover={onUnhover}
+          />
+        );
+      })}
     </group>
   );
 }

--- a/frontend/src/features/aps/components/ThreeViewer/LoadingAndErrorStates.tsx
+++ b/frontend/src/features/aps/components/ThreeViewer/LoadingAndErrorStates.tsx
@@ -13,62 +13,43 @@ export function LoadingAndErrorStates({
   error,
   onErrorClose
 }: LoadingAndErrorStatesProps) {
-  return (
-    <>
-      {/* ローディング状態 */}
-      {isLoading && (
-        <div className="absolute inset-0 flex items-center justify-center bg-black/50 text-white">
-          <div className="text-center">
-            <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-white mx-auto mb-2"></div>
-            <p className="text-sm">Processing mesh data with element info...</p>
+  if (isLoading) {
+    return (
+      <div className="absolute inset-0 bg-black/50 flex items-center justify-center z-40">
+        <div className="bg-white p-6 rounded-lg shadow-lg">
+          <div className="flex items-center space-x-3">
+            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"></div>
+            <div className="text-gray-800">Loading mesh data...</div>
           </div>
         </div>
-      )}
+      </div>
+    );
+  }
 
-      {/* エラー状態 */}
-      {error && (
-        <div className="absolute inset-0 flex items-center justify-center bg-black/50 text-white p-4">
-          <div className="bg-red-800 p-4 rounded-md max-w-md">
-            <h3 className="text-lg font-bold mb-2">Error</h3>
-            <p className="text-sm mb-3">{error}</p>
+  if (error) {
+    return (
+      <div className="absolute inset-0 bg-black/50 flex items-center justify-center z-40">
+        <div className="bg-white p-6 rounded-lg shadow-lg max-w-md">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-lg font-semibold text-red-600">Error</h3>
             <button
               onClick={onErrorClose}
-              className="bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded text-xs"
+              className="text-gray-500 hover:text-gray-700"
             >
-              Close
+              ×
             </button>
           </div>
+          <p className="text-gray-800 mb-4">{error}</p>
+          <button
+            onClick={onErrorClose}
+            className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
+          >
+            Close
+          </button>
         </div>
-      )}
+      </div>
+    );
+  }
 
-      {/* メッシュデータがない場合の表示 */}
-      {!isLoading && !error && meshData.length === 0 && (
-        <div className="absolute inset-0 flex items-center justify-center bg-black/20 text-white">
-          <div className="text-center p-6 bg-black/50 rounded-lg">
-            <div className="text-lg mb-2">No mesh data available</div>
-            <div className="text-sm text-gray-300 mb-4">
-              Load a model in the APS Viewer and click "Extract Mesh"
-            </div>
-            <div className="text-xs text-gray-400">
-              Steps:
-              <ol className="list-decimal list-inside mt-2 space-y-1">
-                <li>Upload a file using the file uploader</li>
-                <li>Wait for the model to load in APS Viewer</li>
-                <li>Click the "Extract Mesh" button</li>
-                <li>Interactive mesh data will appear here</li>
-              </ol>
-            </div>
-            <div className="mt-4 p-3 bg-blue-900/50 rounded text-xs">
-              <div className="font-semibold mb-1">Interactive Features:</div>
-              <div>• Click elements to select and view properties</div>
-              <div>• Hover elements for highlighting</div>
-              <div>• Edit dimensional properties</div>
-              <div>• View element information panel</div>
-              <div>• Real-time property updates</div>
-            </div>
-          </div>
-        </div>
-      )}
-    </>
-  );
+  return null;
 }

--- a/frontend/src/features/aps/components/ThreeViewer/SceneGrid.tsx
+++ b/frontend/src/features/aps/components/ThreeViewer/SceneGrid.tsx
@@ -4,15 +4,15 @@ import { Grid } from '@react-three/drei';
 
 export function SceneGrid() {
   return (
-    <Grid 
-      args={[1000, 1000]} 
-      cellSize={10} 
-      cellThickness={0.5} 
-      cellColor="#6b7280" 
-      sectionSize={100} 
-      sectionThickness={1} 
-      sectionColor="#374151"
-      fadeDistance={500}
+    <Grid
+      args={[100, 100]}
+      cellSize={1}
+      cellThickness={0.5}
+      cellColor="#6f6f6f"
+      sectionSize={10}
+      sectionThickness={1}
+      sectionColor="#9d4b4b"
+      fadeDistance={100}
       fadeStrength={1}
       followCamera={false}
       infiniteGrid={true}

--- a/frontend/src/features/aps/components/ThreeViewer/SceneLighting.tsx
+++ b/frontend/src/features/aps/components/ThreeViewer/SceneLighting.tsx
@@ -3,17 +3,23 @@
 export function SceneLighting() {
   return (
     <>
-      {/* ライティング */}
-      <ambientLight intensity={0.6} />
-      <directionalLight 
-        position={[100, 100, 50]} 
+      {/* 環境光 */}
+      <ambientLight intensity={0.4} />
+      
+      {/* 指向性ライト */}
+      <directionalLight
+        position={[10, 10, 5]}
         intensity={1}
         castShadow
         shadow-mapSize-width={2048}
         shadow-mapSize-height={2048}
       />
-      <pointLight position={[-100, -100, -100]} intensity={0.5} />
-      <pointLight position={[100, -100, 100]} intensity={0.3} />
+      
+      {/* 補助ライト */}
+      <directionalLight
+        position={[-10, -10, -5]}
+        intensity={0.3}
+      />
     </>
   );
 }

--- a/frontend/src/features/aps/components/ThreeViewer/TransformControls.tsx
+++ b/frontend/src/features/aps/components/ThreeViewer/TransformControls.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useThree } from '@react-three/fiber';
+import { TransformControls as DreiTransformControls, OrbitControls } from '@react-three/drei';
+import { useSnapshot } from 'valtio';
+import * as THREE from 'three';
+import { transformState, getCurrentTransformMode, setTransforming } from './store/transformStore';
+import { getCachedMesh } from './SelectableMesh';
+
+export function TransformControls() {
+  const snap = useSnapshot(transformState);
+  const { scene } = useThree();
+  const orbitControlsRef = useRef<any>();
+  const transformControlsRef = useRef<any>();
+  const [selectedObject, setSelectedObject] = useState<THREE.Object3D | null>(null);
+
+  // Get the selected mesh object - 複数の方法で検索
+  const findSelectedObject = () => {
+    if (!snap.selectedElement) return null;
+    
+    const { dbId, fragId } = snap.selectedElement;
+    
+    // 1. キャッシュから取得を試行
+    let foundObject = getCachedMesh(dbId, fragId);
+    if (foundObject && foundObject.parent) {
+      console.log('Found object in cache:', foundObject.name);
+      return foundObject;
+    }
+    
+    // 2. シーン内を検索
+    const objectName = `mesh-${dbId}-${fragId}`;
+    foundObject = null;
+    
+    scene.traverse((child) => {
+      if (child.name === objectName && child instanceof THREE.Mesh) {
+        foundObject = child;
+      }
+    });
+    
+    if (foundObject) {
+      console.log('Found object in scene:', foundObject.name);
+      return foundObject;
+    }
+    
+    console.warn(`Could not find mesh object: ${objectName}`);
+    return null;
+  };
+
+  // Update selected object when selection changes
+  useEffect(() => {
+    const newSelectedObject = findSelectedObject();
+    
+    if (newSelectedObject !== selectedObject) {
+      console.log('Selected object changed:', {
+        old: selectedObject?.name,
+        new: newSelectedObject?.name,
+        hasParent: newSelectedObject?.parent ? true : false,
+        inScene: newSelectedObject ? scene.getObjectById(newSelectedObject.id) !== undefined : false
+      });
+      
+      setSelectedObject(newSelectedObject);
+    }
+  }, [snap.selectedElement, scene]);
+
+  // Validate object is still in scene graph - より頻繁にチェック
+  useEffect(() => {
+    if (!selectedObject) return;
+
+    const validateObject = () => {
+      const isInScene = selectedObject.parent && scene.getObjectById(selectedObject.id) !== undefined;
+      if (!isInScene) {
+        console.warn('Selected object is no longer in scene graph, searching again...');
+        const newObject = findSelectedObject();
+        if (newObject) {
+          console.log('Found replacement object');
+          setSelectedObject(newObject);
+        } else {
+          console.warn('Could not find replacement object, clearing selection');
+          setSelectedObject(null);
+        }
+      }
+    };
+
+    // 初回チェック
+    validateObject();
+
+    // 定期的にチェック
+    const interval = setInterval(validateObject, 100);
+
+    return () => clearInterval(interval);
+  }, [selectedObject, scene]);
+
+  // Handle transform controls events
+  useEffect(() => {
+    const transformControls = transformControlsRef.current;
+    const orbitControls = orbitControlsRef.current;
+
+    if (!transformControls || !orbitControls || !selectedObject) return;
+
+    // Verify object is still valid before setting up events
+    const isObjectValid = selectedObject.parent && scene.getObjectById(selectedObject.id);
+    if (!isObjectValid) {
+      console.warn('Object is not valid for transform controls');
+      return;
+    }
+
+    console.log('Setting up transform controls for:', selectedObject.name);
+
+    // Event handlers
+    const handleDragStart = (event: any) => {
+      console.log('Transform drag started');
+      setTransforming(true);
+      orbitControls.enabled = false;
+    };
+
+    const handleDragEnd = (event: any) => {
+      console.log('Transform drag ended');
+      setTransforming(false);
+      orbitControls.enabled = true;
+    };
+
+    const handleObjectChange = () => {
+      if (selectedObject && snap.selectedElement) {
+        // Verify object is still valid
+        if (!selectedObject.parent || !scene.getObjectById(selectedObject.id)) {
+          console.warn('Object became invalid during transform');
+          return;
+        }
+
+        const position = selectedObject.position;
+        const rotation = selectedObject.rotation;
+        const scale = selectedObject.scale;
+        
+        // Dispatch custom event for position change
+        const transformEvent = new CustomEvent('elementTransformChanged', {
+          detail: {
+            dbId: snap.selectedElement.dbId,
+            fragId: snap.selectedElement.fragId,
+            position: { x: position.x, y: position.y, z: position.z },
+            rotation: { x: rotation.x, y: rotation.y, z: rotation.z },
+            scale: { x: scale.x, y: scale.y, z: scale.z },
+            element: snap.selectedElement
+          }
+        });
+        window.dispatchEvent(transformEvent);
+      }
+    };
+
+    // Add event listeners
+    transformControls.addEventListener('dragging-changed', handleDragStart);
+    transformControls.addEventListener('objectChange', handleObjectChange);
+
+    // Cleanup
+    return () => {
+      try {
+        if (transformControls) {
+          transformControls.removeEventListener('dragging-changed', handleDragStart);
+          transformControls.removeEventListener('objectChange', handleObjectChange);
+        }
+      } catch (error) {
+        console.warn('Error removing transform controls event listeners:', error);
+      }
+    };
+  }, [selectedObject, snap.selectedElement, scene]);
+
+  // TransformControlsが無効なオブジェクトを参照しないようにする
+  const isValidObject = selectedObject && selectedObject.parent && scene.getObjectById(selectedObject.id);
+
+  return (
+    <>
+      {/* Orbit Controls */}
+      <OrbitControls
+        ref={orbitControlsRef}
+        makeDefault
+        minPolarAngle={0}
+        maxPolarAngle={Math.PI / 1.75}
+        enablePan={true}
+        enableZoom={true}
+        enableRotate={true}
+      />
+      
+      {/* Transform Controls - only show when an element is selected and object is valid */}
+      {isValidObject && (
+        <DreiTransformControls
+          ref={transformControlsRef}
+          object={selectedObject}
+          mode={getCurrentTransformMode()}
+          showX={true}
+          showY={true}
+          showZ={true}
+          size={1}
+          space="world"
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/features/aps/components/ThreeViewer/global.d.ts
+++ b/frontend/src/features/aps/components/ThreeViewer/global.d.ts
@@ -4,6 +4,27 @@ declare global {
   interface Window {
     extractedGeometries: ExtractedMeshData[];
   }
+
+  interface WindowEventMap {
+    'meshDataExtracted': CustomEvent<{
+      meshData: ExtractedMeshData[];
+    }>;
+    'elementPropertyChanged': CustomEvent<{
+      dbId: number;
+      fragId: number;
+      property: string;
+      value: any;
+      element: ExtractedMeshData;
+    }>;
+    'elementTransformChanged': CustomEvent<{
+      dbId: number;
+      fragId: number;
+      position: { x: number; y: number; z: number };
+      rotation: { x: number; y: number; z: number };
+      scale: { x: number; y: number; z: number };
+      element: ExtractedMeshData;
+    }>;
+  }
 }
 
 export {};

--- a/frontend/src/features/aps/components/ThreeViewer/index.ts
+++ b/frontend/src/features/aps/components/ThreeViewer/index.ts
@@ -4,5 +4,19 @@ export type {
   SelectableMeshProps, 
   ElementInfoPanelProps,
   ExtractedMeshesProps,
-  CameraControllerProps 
+  CameraControllerProps,
+  TransformInfo,
+  TransformChangeEvent
 } from './types';
+
+// Transform store exports
+export { 
+  transformState, 
+  transformModes, 
+  setSelectedElement, 
+  setHoveredElement, 
+  cycleTransformMode, 
+  setTransforming, 
+  getCurrentTransformMode 
+} from './store/transformStore';
+export type { TransformMode, TransformState } from './store/transformStore';

--- a/frontend/src/features/aps/components/ThreeViewer/store/transformStore.ts
+++ b/frontend/src/features/aps/components/ThreeViewer/store/transformStore.ts
@@ -1,0 +1,55 @@
+import { proxy } from 'valtio';
+import { ExtractedMeshData } from '../types';
+
+export type TransformMode = 'translate' | 'rotate' | 'scale';
+
+export interface TransformState {
+  selectedElement: ExtractedMeshData | null;
+  hoveredElement: ExtractedMeshData | null;
+  mode: number; // 参考例と同じく数値インデックス
+  isTransforming: boolean;
+}
+
+// 参考例と同じモード配列
+export const transformModes: TransformMode[] = ['translate', 'rotate', 'scale'];
+
+// Valtio proxy state - 参考例のパターン
+export const transformState = proxy<TransformState>({
+  selectedElement: null,
+  hoveredElement: null,
+  mode: 0, // 0=translate, 1=rotate, 2=scale
+  isTransforming: false
+});
+
+// Actions
+export const setSelectedElement = (element: ExtractedMeshData | null) => {
+  console.log('Transform store: Setting selected element:', element?.dbId);
+  transformState.selectedElement = element;
+};
+
+export const setHoveredElement = (element: ExtractedMeshData | null) => {
+  transformState.hoveredElement = element;
+};
+
+export const cycleTransformMode = () => {
+  const oldMode = transformState.mode;
+  transformState.mode = (transformState.mode + 1) % transformModes.length;
+  console.log('Transform mode cycled:', transformModes[oldMode], '->', transformModes[transformState.mode]);
+};
+
+export const setTransforming = (isTransforming: boolean) => {
+  console.log('Transform state changed:', isTransforming);
+  transformState.isTransforming = isTransforming;
+};
+
+export const getCurrentTransformMode = (): TransformMode => {
+  return transformModes[transformState.mode];
+};
+
+// Reset function
+export const resetTransformState = () => {
+  transformState.selectedElement = null;
+  transformState.hoveredElement = null;
+  transformState.mode = 0;
+  transformState.isTransforming = false;
+};

--- a/frontend/src/features/aps/components/ThreeViewer/types.ts
+++ b/frontend/src/features/aps/components/ThreeViewer/types.ts
@@ -22,6 +22,12 @@ export interface ExtractedMeshData {
       size: number[];
     };
   };
+  // Transform情報を追加
+  transform?: {
+    position: { x: number; y: number; z: number };
+    rotation: { x: number; y: number; z: number };
+    scale: { x: number; y: number; z: number };
+  };
 }
 
 // コンポーネントのProps型定義
@@ -51,4 +57,20 @@ export interface ExtractedMeshesProps {
 
 export interface CameraControllerProps {
   meshData: ExtractedMeshData[];
+}
+
+// Transform関連の型定義を追加
+export interface TransformInfo {
+  position: { x: number; y: number; z: number };
+  rotation: { x: number; y: number; z: number };
+  scale: { x: number; y: number; z: number };
+}
+
+export interface TransformChangeEvent {
+  dbId: number;
+  fragId: number;
+  position: { x: number; y: number; z: number };
+  rotation: { x: number; y: number; z: number };
+  scale: { x: number; y: number; z: number };
+  element: ExtractedMeshData;
 }


### PR DESCRIPTION
## 変更内容
### メッシュモデルの要素の変形操作機能の実装
React Three Fiber Viewerにおいて、表示されているメッシュモデルの各要素に対して変形操作（位置移動、回転、スケール変更）を行える機能を実装。

## 主な変更点
- `TransformControls`コンポーネントの追加
  - 選択された要素に対して変形操作用のギズモを表示
  - 操作モード（移動、回転、スケール）の切り替え機能
- `transformStore`の実装
  - valtioを使用した状態管理
  - 選択要素、操作モード、変形状態の管理
- イベント処理の拡張
  - 変形操作中のカメラ制御の一時停止
  - 変形情報の更新イベントの発行
- UI改善
  - 現在の操作モードの表示
  - 操作ガイドの表示

## 技術的詳細
- `@react-three/drei`の`TransformControls`を使用して変形操作UIを実装
- valtioを使用して変形状態を管理（zustandと併用）
- カスタムイベント`elementTransformChanged`を追加して変形情報を通知
- 選択状態と変形状態の同期メカニズムを実装

## 使用方法
1. 要素をクリックして選択
2. ギズモをドラッグして変形操作
3. 要素を右クリックするか、UIボタンで操作モードを切り替え（移動→回転→スケール）

## 参考
https://codesandbox.io/p/sandbox/btsbj を参考に実装

## 関連
close #40
